### PR TITLE
Rebuild 0.15.0 for openssl 1 and 3 and new libevent for aarch64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,7 +21,7 @@ source:
   {% endif %}
 
 build:
-  number: 1
+  number: 2
   run_exports:
     - {{ pin_subpackage("libthrift", max_pin="x.x") }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
         - openssl {{ openssl }}
         - zlib {{ zlib }}
       run:
-        - openssl {{ openssl }}
+        - openssl  # exact pin handled through openssl run_exports
         - zlib
         - libevent
         - boost-cpp >={{ boost_cpp }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ outputs:
         - openssl {{ openssl }}
         - zlib {{ zlib }}
       run:
-        - openssl 3.*
+        - openssl {{ openssl }}
         - zlib
         - libevent
         - boost-cpp >={{ boost_cpp }}


### PR DESCRIPTION
thrift for openssl 1 (build 0) has different requirements for `linux-aarch64` (`libevent >=2.1.10,<2.1.11.0a0` instead of `libevent >=2.1.8,<2.2.0a0`). This causes conflicts with packages like `qt-main`, which pulls in `libevent 2.1.12`.

# Changes

- Update build number
- Replace hard-coded `openssl 3` with template parameter