### PR TITLE
Add openssl to metapackage requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -120,15 +120,11 @@ outputs:
         - {{ pin_subpackage("libthrift", max_pin="x.x") }}
     requirements:
       host:
-        - {{ pin_subpackage("libthrift", exact=true) }}
-        - {{ pin_subpackage("thrift-compiler", exact=true) }}
-        # openssl needs to be added here so it can be used for the sha calculation
-        # otherwise, only one metapackage will be built.
-        # This can be removed as soon as openssl 1.1.1 is dropped
-        - openssl {{ openssl }}
+        - {{ pin_subpackage("libthrift", max_pin="x.x.x") }}
+        - {{ pin_subpackage("thrift-compiler", max_pin="x.x.x") }}
       run:
-        - {{ pin_subpackage("libthrift", exact=true) }}
-        - {{ pin_subpackage("thrift-compiler", exact=true) }}
+        - {{ pin_subpackage("libthrift", max_pin="x.x.x") }}
+        - {{ pin_subpackage("thrift-compiler", max_pin="x.x.x") }}
 
 about:
   home: https://thrift.apache.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,6 +122,10 @@ outputs:
       host:
         - {{ pin_subpackage("libthrift", exact=true) }}
         - {{ pin_subpackage("thrift-compiler", exact=true) }}
+        # openssl needs to be added here so it can be used for the sha calculation
+        # otherwise, only one metapackage will be built.
+        # This can be removed as soon as openssl 1.1.1 is dropped
+        - openssl {{ openssl }}
       run:
         - {{ pin_subpackage("libthrift", exact=true) }}
         - {{ pin_subpackage("thrift-compiler", exact=true) }}


### PR DESCRIPTION
This is required so that the `thrift-cpp` metapackage is built for both openssl variants.

If it's not included, the metapackage will have the same sha and thus be overwritten by conda-build.

No bump in build number needed because the other version has never been uploaded.